### PR TITLE
Update helm chart to work on Minikube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 work/
+
+.idea/

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -60,7 +60,7 @@ Cd to the manifests directory and install the manifests in the default
 namespace. 
 
 ```
-cd manifest
+cd manifests
 kubectl apply -f gp3-encrypted-fast-storage-class.yaml
 kubectl apply -f keeper.yaml
 kubectl apply -f swarm.yaml

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -69,7 +69,27 @@ kubectl apply -f vector.yaml
 
 #### Using helm
 
-The helm script is in the helm directory. It's under development. 
+The helm script is in the helm directory. It's under development.
+
+In the `helm` directory, run the following to install the helm chart:
+
+```shell
+helm install antalya-test ./
+```
+
+On Minikube, run:
+
+```shell
+helm install antalya-test ./ -f values-minikube.yaml
+```
+
+This will deploy MinIO for local object storage.
+
+To uninstall, run:
+
+```shell
+helm uninstall antalya-test
+```
 
 ## Running
 

--- a/kubernetes/helm/templates/etcd.yaml
+++ b/kubernetes/helm/templates/etcd.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ice-rest-catalog-etcd
+  labels:
+    app: ice-rest-catalog-etcd
+spec:
+  replicas: 1 # change to 3
+  selector:
+    matchLabels:
+      app: ice-rest-catalog-etcd
+  serviceName: ice-rest-catalog-etcd
+  template:
+    metadata:
+      name: ice-rest-catalog-etcd
+      labels:
+        app: ice-rest-catalog-etcd
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2381"
+    spec:
+      containers:
+        - name: etcd
+          image: quay.io/coreos/etcd:v3.5.4
+          ports:
+            - containerPort: 2379
+              name: client
+            - containerPort: 2380
+              name: peer
+            - containerPort: 2381
+              name: metrics
+          volumeMounts:
+            - name: data
+              mountPath: /var/run/etcd
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ETCD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ETCD_LISTEN_PEER_URLS
+              value: http://0.0.0.0:2380
+            - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+              value: http://$(ETCD_NAME).ice-rest-catalog-etcd.$(NAMESPACE).svc.cluster.local:2380
+            - name: ETCD_LISTEN_CLIENT_URLS
+              value: http://0.0.0.0:2379
+            - name: ETCD_ADVERTISE_CLIENT_URLS
+              value: http://$(ETCD_NAME).ice-rest-catalog-etcd.$(NAMESPACE).svc.cluster.local:2379
+            - name: ETCD_INITIAL_CLUSTER_TOKEN
+              value: ice-rest-catalog-etcd
+            - name: ETCD_INITIAL_CLUSTER
+              value: ice-rest-catalog-etcd-0=http://ice-rest-catalog-etcd-0.ice-rest-catalog-etcd.$(NAMESPACE).svc.cluster.local:2380
+              # replace with if you change number of replicas to 3
+              # value: ice-rest-catalog-etcd-0=http://ice-rest-catalog-etcd-0.ice-rest-catalog-etcd:2380,ice-rest-catalog-etcd-1=http://ice-rest-catalog-etcd-1.ice-rest-catalog-etcd:2380,ice-rest-catalog-etcd-2=http://ice-rest-catalog-etcd-2.ice-rest-catalog-etcd:2380
+            - name: ETCD_INITIAL_CLUSTER_STATE
+              valueFrom:
+                configMapKeyRef:
+                  name: ice-rest-catalog-etcd
+                  key: ETCD_INITIAL_CLUSTER_STATE
+            - name: ETCD_LISTEN_METRICS_URLS
+              value: http://0.0.0.0:2381
+            - name: ETCD_DATA_DIR
+              value: /var/run/etcd/ice-rest-catalog.etcd
+            - name: ETCD_QUOTA_BACKEND_BYTES
+              value: "8589934592" # 8Gi
+            - name: ETCD_AUTO_COMPACTION_RETENTION
+              value: "1"
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              path: /health
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 15
+          startupProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /health
+              port: 2381
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 15
+      affinity:
+        # explanation: put pods in different AZs
+        podAntiAffinity:
+          # change to requiredDuringSchedulingIgnoredDuringExecution if needed (note: you'll need to remove podAffinityTerm/weight)
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: ice-rest-catalog-etcd
+                topologyKey: topology.kubernetes.io/zone
+              weight: 100
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        storageClassName: {{ if .Values.etcd.storage.class }}{{ .Values.etcd.storage.class }}{{ else }}{{ .Values.global.storageClass }}{{ end }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ice-rest-catalog-etcd
+spec:
+  clusterIP: None
+  ports:
+    - port: 2379
+      name: client
+    - port: 2380
+      name: peer
+    - port: 2381
+      name: metrics
+  selector:
+    app: ice-rest-catalog-etcd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ice-rest-catalog-etcd
+data:
+  ETCD_INITIAL_CLUSTER_STATE: "new"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ice-rest-catalog-etcd
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: ice-rest-catalog-etcd

--- a/kubernetes/helm/templates/ice-rest-catalog.yaml
+++ b/kubernetes/helm/templates/ice-rest-catalog.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ice-rest-catalog
+stringData:
+  ice-rest-catalog.yaml: |
+    # uri: jdbc:sqlite:file:/var/lib/ice-rest-catalog/db.sqlite?journal_mode=WAL&synchronous=OFF&journal_size_limit=500
+    uri: etcd:http://ice-rest-catalog-etcd:2379
+    warehouse: s3://{{ .Values.iceRestCatalog.catalogBucket }}
+    s3:
+      endpoint: {{ .Values.iceRestCatalog.s3.endpoint }}
+      pathStyleAccess: true
+      accessKeyID: {{ .Values.iceRestCatalog.s3.accessKeyID }}
+      secretAccessKey: {{ .Values.iceRestCatalog.s3.secretAccessKey }}
+      region: {{ .Values.iceRestCatalog.s3.region }}
+    bearerTokens:
+    - value: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ice-rest-catalog
+spec:
+  selector:
+    app: ice-rest-catalog
+  ports:
+    - port: 5000
+      name: iceberg
+    - port: 5001
+      name: debug
+---
+# this can be a simple Deployment without volumes when uri is ectd:...
+# keeping it StatefulSet for testing purposes only
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ice-rest-catalog
+  labels:
+    app: ice-rest-catalog
+spec:
+  serviceName: ice-rest-catalog
+  selector:
+    matchLabels:
+      app: ice-rest-catalog
+  template:
+    metadata:
+      labels:
+        app: ice-rest-catalog
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5001"
+    spec:
+      volumes:
+        - name: etc
+          secret:
+            secretName: ice-rest-catalog
+      containers:
+        - name: iceberg
+          # image: altinity/ice-rest-catalog:latest
+          image: altinity/ice-rest-catalog:debug-with-ice-0.0.0-SNAPSHOT
+          imagePullPolicy: "Always" # for test purposes only
+          ports:
+            - containerPort: 5000 # iceberg
+            - containerPort: 5001 # /{healthz,livez,readyz,metrics}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 5001
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 5001
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: etc
+              mountPath: /etc/ice
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/ice-rest-catalog
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        storageClassName: {{ if .Values.iceRestCatalog.storage.class }}{{ .Values.iceRestCatalog.storage.class }}{{ else }}{{ .Values.global.storageClass }}{{ end }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/kubernetes/helm/templates/minio.yaml
+++ b/kubernetes/helm/templates/minio.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.minio.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio
+  labels:
+    app.kubernetes.io/name: minio
+spec:
+  serviceName: minio-headless
+  replicas: {{ .Values.minio.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - name: minio
+          image: {{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{ .Values.minio.rootUser }}
+            - name: MINIO_ROOT_PASSWORD
+              value: {{ .Values.minio.rootPassword }}
+            - name: MINIO_DOMAIN
+              value: minio
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: minio-data
+        labels:
+          app.kubernetes.io/name: minio
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app.kubernetes.io/name: minio
+spec:
+  type: NodePort
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  selector:
+    app.kubernetes.io/name: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-headless
+  labels:
+    app.kubernetes.io/name: minio
+spec:
+  clusterIP: None
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-init
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-03-12T17-29-24Z
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.minio.rootUser }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.minio.rootPassword }}
+            - name: AWS_REGION
+              value: {{ .Values.minio.awsRegion }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              until (/usr/bin/mc alias set minio http://minio:9000 {{ .Values.minio.rootUser }} {{ .Values.minio.rootPassword }}); do echo '...waiting...' && sleep 1; done;
+              /usr/bin/mc mb minio/warehouse --ignore-existing;
+              /usr/bin/mc anonymous set public minio/warehouse;
+{{- end }}

--- a/kubernetes/helm/templates/swarm.yaml
+++ b/kubernetes/helm/templates/swarm.yaml
@@ -12,7 +12,6 @@ spec:
               podTemplate: replica
               volumeClaimTemplate: storage
           shardsCount: {{ .Values.swarm.shardsCount }}
-        templates:
     zookeeper:
         nodes:
         - host: keeper-keeper

--- a/kubernetes/helm/templates/vector.yaml
+++ b/kubernetes/helm/templates/vector.yaml
@@ -12,7 +12,6 @@ spec:
               podTemplate: replica
               volumeClaimTemplate: storage
           shardsCount: {{ .Values.vector.shardsCount }}
-        templates:
     zookeeper:
         nodes:
         - host: keeper-keeper

--- a/kubernetes/helm/values-minikube.yaml
+++ b/kubernetes/helm/values-minikube.yaml
@@ -1,6 +1,6 @@
 # Global settings
 global:
-  storageClass: "gp3-encrypted"
+  storageClass: "standard"
 
 # ClickHouse Keeper settings
 keeper:
@@ -8,7 +8,7 @@ keeper:
   replicasCount: 3
   storage:
     class: ""  # Defaults to global.storageClass if empty
-    size: "25Gi"
+    size: "5Gi"
   image:
     repository: "altinity/clickhouse-keeper"
     tag: "25.8.12.20747.altinityantalya"
@@ -22,9 +22,8 @@ vector:
     count: 1
     storage:
       class: ""  # Defaults to global.storageClass if empty
-      size: "50Gi"
+      size: "10Gi"
     nodeSelector:
-      "node.kubernetes.io/instance-type": "m6i.large"
     tolerations:
       - key: "dedicated"
         operator: "Equal"
@@ -42,9 +41,8 @@ swarm:
     count: 1
     storage:
       class: ""  # Defaults to global.storageClass if empty
-      size: "50Gi"
+      size: "10Gi"
     nodeSelector:
-      "node.kubernetes.io/instance-type": "m6i.xlarge"
     tolerations:
       - key: "antalya"
         operator: "Equal"
@@ -55,27 +53,18 @@ swarm:
         value: "clickhouse"
         effect: "NoSchedule"
     affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "clickhouse.altinity.com/app"
-                  operator: In
-                  values:
-                    - "chop"
-            topologyKey: "kubernetes.io/hostname"
   image:
     repository: "altinity/clickhouse-server"
     tag: "25.8.12.20747.altinityantalya"
 
 # Ice Rest Catalog settings
 iceRestCatalog:
-  catalogBucket: bucket1
+  catalogBucket: warehouse
   s3:
-    endpoint: ""
-    accessKeyID: ""
-    secretAccessKey: ""
-    region: us-east-1
+    endpoint: "http://minio:9000"
+    accessKeyID: minio
+    secretAccessKey: minio123
+    region: minio
   storage:
     class: "" # Defaults to global.storageClass if empty
 
@@ -85,4 +74,11 @@ etcd:
     class: "" # Defaults to global.storageClass if empty
 
 minio:
-  enabled: false
+  enabled: true
+  rootUser: minio
+  rootPassword: minio123
+  awsRegion: minio
+  image:
+    repository: quay.io/minio/minio
+    tag: RELEASE.2025-03-12T18-04-18Z
+  replicas: 1

--- a/kubernetes/manifests/keeper.yaml
+++ b/kubernetes/manifests/keeper.yaml
@@ -20,7 +20,7 @@ spec:
           containers:
             - name: clickhouse-keeper
               imagePullPolicy: IfNotPresent
-              image: "altinity/clickhouse-keeper:25.8.9.20496.altinityantalya"
+              image: "altinity/clickhouse-keeper:25.8.12.20747.altinityantalya"
     volumeClaimTemplates:
       - name: default
         metadata:

--- a/kubernetes/manifests/swarm.yaml
+++ b/kubernetes/manifests/swarm.yaml
@@ -80,7 +80,7 @@ spec:
                   topologyKey: "kubernetes.io/hostname"
           containers:
           - name: clickhouse
-            image: altinity/clickhouse-server:25.8.9.20496.altinityantalya
+            image: altinity/clickhouse-server:25.8.12.20747.altinityantalya
     volumeClaimTemplates:
       - name: storage
         # Uncomment for prod systems. You will then need to delete PVCs manually. 

--- a/kubernetes/manifests/vector.yaml
+++ b/kubernetes/manifests/vector.yaml
@@ -43,7 +43,7 @@ spec:
             node.kubernetes.io/instance-type: m6i.large
           containers:
           - name: clickhouse
-            image: altinity/clickhouse-server:25.8.9.20496.altinityantalya
+            image: altinity/clickhouse-server:25.8.12.20747.altinityantalya
           tolerations:
           - key: "dedicated"
             operator: "Equal"


### PR DESCRIPTION
Updates the chart in kubernetes/helm to work on Minikube with a new `values-minikube.yaml` config. Helm now deploys ice-rest-catalog, etcd, and minio. Also updates the antalya image versions in both helm and the `manifests` directory to latest.