### PR TITLE
Fix helm on eks

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -71,11 +71,20 @@ kubectl apply -f vector.yaml
 
 The helm script is in the helm directory. It's under development.
 
-In the `helm` directory, run the following to install the helm chart:
+##### EKS
+
+In the `helm` directory, run the following to install the helm chart on EKS.
+Replace `bucket-name` with your S3 bucket name.
 
 ```shell
-helm install antalya-test ./
+helm install antalya-test ./ --set iceRestCatalog.catalogBucket=bucket-name
 ```
+
+This requires a service account named `ice-rest-catalog` set up from the instructions [here](ice/README.md).
+To use a different service account name, add `--set iceRestCatalog.serviceAccountName=new-account-name` to
+the end of the `helm install` command above.
+
+##### Minikube
 
 On Minikube, run:
 
@@ -84,6 +93,8 @@ helm install antalya-test ./ -f values-minikube.yaml
 ```
 
 This will deploy MinIO for local object storage.
+
+##### Uninstalling
 
 To uninstall, run:
 

--- a/kubernetes/helm/templates/ice-rest-catalog.yaml
+++ b/kubernetes/helm/templates/ice-rest-catalog.yaml
@@ -8,10 +8,12 @@ stringData:
     uri: etcd:http://ice-rest-catalog-etcd:2379
     warehouse: s3://{{ .Values.iceRestCatalog.catalogBucket }}
     s3:
+{{ if .Values.minio.enabled }}
       endpoint: {{ .Values.iceRestCatalog.s3.endpoint }}
-      pathStyleAccess: true
       accessKeyID: {{ .Values.iceRestCatalog.s3.accessKeyID }}
       secretAccessKey: {{ .Values.iceRestCatalog.s3.secretAccessKey }}
+{{ end }}
+      pathStyleAccess: true
       region: {{ .Values.iceRestCatalog.s3.region }}
     bearerTokens:
     - value: foo
@@ -50,6 +52,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "5001"
     spec:
+{{ if .Values.iceRestCatalog.serviceAccountName }}
+      serviceAccountName: {{ .Values.iceRestCatalog.serviceAccountName }}
+{{ end }}
       volumes:
         - name: etc
           secret:

--- a/kubernetes/helm/templates/swarm.yaml
+++ b/kubernetes/helm/templates/swarm.yaml
@@ -16,6 +16,17 @@ spec:
         nodes:
         - host: keeper-keeper
           port: 2181
+    users:
+      cache_enabled/networks/ip: "::/0"
+      cache_enabled/password: topsecret
+      cache_enabled/profile: default
+    profiles:
+      default/enable_filesystem_cache: 0
+      #default/enable_filesystem_cache_log: 1
+      default/filesystem_cache_name: "s3_parquet_cache"
+      cache_enabled/enable_filesystem_cache: 1
+      #cache_enabled/enable_filesystem_cache_log: 1
+      cache_enabled/filesystem_cache_name: "s3_parquet_cache"
     files:
       config.d/remote_servers.xml: |
         <clickhouse>

--- a/kubernetes/helm/templates/swarm.yaml
+++ b/kubernetes/helm/templates/swarm.yaml
@@ -22,10 +22,8 @@ spec:
       cache_enabled/profile: default
     profiles:
       default/enable_filesystem_cache: 0
-      #default/enable_filesystem_cache_log: 1
       default/filesystem_cache_name: "s3_parquet_cache"
       cache_enabled/enable_filesystem_cache: 1
-      #cache_enabled/enable_filesystem_cache_log: 1
       cache_enabled/filesystem_cache_name: "s3_parquet_cache"
     files:
       config.d/remote_servers.xml: |

--- a/kubernetes/helm/templates/vector.yaml
+++ b/kubernetes/helm/templates/vector.yaml
@@ -16,6 +16,8 @@ spec:
         nodes:
         - host: keeper-keeper
           port: 2181
+    users:
+      root/password: topsecret
     files:
       config.d/remote_servers.xml: |
         <clickhouse>

--- a/kubernetes/helm/values-minikube.yaml
+++ b/kubernetes/helm/values-minikube.yaml
@@ -60,6 +60,7 @@ swarm:
 # Ice Rest Catalog settings
 iceRestCatalog:
   catalogBucket: warehouse
+  serviceAccountName:
   s3:
     endpoint: "http://minio:9000"
     accessKeyID: minio

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -70,12 +70,13 @@ swarm:
 
 # Ice Rest Catalog settings
 iceRestCatalog:
-  catalogBucket: bucket1
+  catalogBucket: bucket-name
+  serviceAccountName: ice-rest-catalog
   s3:
-    endpoint: ""
+    endpoint: http://s3.us-west-2.amazonaws.com
+    region: us-west-2
     accessKeyID: ""
     secretAccessKey: ""
-    region: us-east-1
   storage:
     class: "" # Defaults to global.storageClass if empty
 


### PR DESCRIPTION
Currently, there are issues with the helm chart in `kubernetes/helm` when running on EKS (some tests from `python/tests` fail when run using `--profile=kubernetes`). This mainly had to do with connection issues with ice-rest-catalog and authentication.

Fixes the helm chart when using the default values.yaml for EKS to pass all tests in `python/tests`. Improves documentation for using the helm chart on EKS.