### PR TITLE
Update ClickHouse and ice-rest-catalog image tags in helm chart

### DIFF
--- a/kubernetes/helm/templates/ice-rest-catalog.yaml
+++ b/kubernetes/helm/templates/ice-rest-catalog.yaml
@@ -14,7 +14,9 @@ stringData:
       secretAccessKey: {{ .Values.iceRestCatalog.s3.secretAccessKey }}
       region: {{ .Values.iceRestCatalog.s3.region }}
     bearerTokens:
-    - value: foo
+    - value: {{ .Values.iceRestCatalog.bearerToken }}
+    anonymousAccess:
+      enabled: false
 ---
 apiVersion: v1
 kind: Service
@@ -56,8 +58,7 @@ spec:
             secretName: ice-rest-catalog
       containers:
         - name: iceberg
-          # image: altinity/ice-rest-catalog:latest
-          image: altinity/ice-rest-catalog:debug-with-ice-0.0.0-SNAPSHOT
+          image: "{{ .Values.iceRestCatalog.image.repository }}:{{ .Values.iceRestCatalog.image.tag }}"
           imagePullPolicy: "Always" # for test purposes only
           ports:
             - containerPort: 5000 # iceberg

--- a/kubernetes/helm/values-minikube.yaml
+++ b/kubernetes/helm/values-minikube.yaml
@@ -11,7 +11,7 @@ keeper:
     size: "5Gi"
   image:
     repository: "altinity/clickhouse-keeper"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
     pullPolicy: "IfNotPresent"
 
 # ClickHouse Vector settings
@@ -31,7 +31,7 @@ vector:
         effect: "NoSchedule"
   image:
     repository: "altinity/clickhouse-server"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
 
 # ClickHouse Swarm settings
 swarm:
@@ -55,7 +55,7 @@ swarm:
     affinity:
   image:
     repository: "altinity/clickhouse-server"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
 
 # Ice Rest Catalog settings
 iceRestCatalog:
@@ -67,6 +67,9 @@ iceRestCatalog:
     region: minio
   storage:
     class: "" # Defaults to global.storageClass if empty
+  image:
+    repository: "altinity/ice-rest-catalog"
+    tag: "debug-with-ice-0.19.0"
 
 # etcd settings
 etcd:

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -11,7 +11,7 @@ keeper:
     size: "25Gi"
   image:
     repository: "altinity/clickhouse-keeper"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
     pullPolicy: "IfNotPresent"
 
 # ClickHouse Vector settings
@@ -32,7 +32,7 @@ vector:
         effect: "NoSchedule"
   image:
     repository: "altinity/clickhouse-server"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
 
 # ClickHouse Swarm settings
 swarm:
@@ -66,11 +66,12 @@ swarm:
             topologyKey: "kubernetes.io/hostname"
   image:
     repository: "altinity/clickhouse-server"
-    tag: "25.8.12.20747.altinityantalya"
+    tag: "26.3.13.20001.altinityantalya"
 
 # Ice Rest Catalog settings
 iceRestCatalog:
   catalogBucket: bucket1
+  bearerToken: foo
   s3:
     endpoint: ""
     accessKeyID: ""
@@ -78,6 +79,9 @@ iceRestCatalog:
     region: us-east-1
   storage:
     class: "" # Defaults to global.storageClass if empty
+  image:
+    repository: "altinity/ice-rest-catalog"
+    tag: "debug-with-ice-0.19.0"
 
 # etcd settings
 etcd:


### PR DESCRIPTION
Updates ClickHouse to 26.3 Antalya and ice-rest-catalog to 0.19.0 in helm chart. Makes more values in ice-rest-catalog configurable.